### PR TITLE
Removed gulp-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var through = require('through2'),
 	flowRemoveTypes = require('flow-remove-types'),
-	gutil = require('gulp-util'),
-	PluginError = gutil.PluginError;
+	Vinyl = require('vinyl'),
+	PluginError = require('plugin-error');
 
 module.exports = function gulpFlowRemoveTypes(options) {
 	if(!options) {
@@ -22,7 +22,7 @@ module.exports = function gulpFlowRemoveTypes(options) {
 
 				//sourceMap option support
 				if(options.sourceMap) {
-					this.push(new gutil.File({
+					this.push(new Vinyl({
 						cwd: file.cwd,
 						base: file.base,
 						path: file.path + '.map',

--- a/index.js
+++ b/index.js
@@ -30,13 +30,16 @@ module.exports = function gulpFlowRemoveTypes(options) {
 					}))
 				}
 
-				cb();
+				return cb();
 			}
 			catch (err) {
-				throw new PluginError('gulp-flow-remove-types', err);
+				return cb(new PluginError('gulp-flow-remove-types', err.message, {
+					lineNumber: err.loc.line,
+					fileName: file.path ? file.relative : null
+				}));
 			}
 		} else if (file.isStream()) {
-			throw new PluginError('gulp-flow-remove-types', 'Streams are not supported!');
+			return cb(new PluginError('gulp-flow-remove-types', 'Streams are not supported!'));
 		}
 	});
 };

--- a/package.json
+++ b/package.json
@@ -13,8 +13,9 @@
   },
   "dependencies": {
     "flow-remove-types": "^1.2.1",
-    "gulp-util": "^3.0.8",
-    "through2": "^2.0.3"
+    "plugin-error": "^1.0.1",
+    "through2": "^2.0.3",
+    "vinyl": "^2.1.0"
   },
   "devDependencies": {
     "coveralls": "^2.13.1",

--- a/test/fixtures/error.js
+++ b/test/fixtures/error.js
@@ -1,0 +1,4 @@
+// @flow
+function square(n: number): number {
+	return * n;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -60,4 +60,15 @@ describe('gulp-javascript-obfuscator', function () {
 		});
 	});
 
+	it('should print error', (done) => {
+		
+		const stream = gulp.src(['test/fixtures/error.js']).pipe(gulpFlowRemoveTypes({sourceMap: true}).on('error',(error) => {
+			expect(error.message).toBe("Unexpected token (3:8)");
+			expect(error.lineNumber).toBe(3);
+			expect(error.fileName).toBe("error.js");
+			done();
+		}));
+		
+	});
+
 });


### PR DESCRIPTION
As seen in https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5 gulp-util is being deprecated.
This PR performs the changes proposed (gulpUtils.File to Vinyl and gulpUtils.PluginError to PluginError) and removes the gulp-util dependency